### PR TITLE
デバック修正

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,4 +4,9 @@ class Address < ApplicationRecord
   validates :postal_code, presence: true, length: { is: 7 }
   validates :address, presence: true
   validates :name, presence: true
+  
+  def full_address
+    "〒#{postal_code} #{address} #{name}"
+  end
+
 end

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -33,8 +33,8 @@
   <% @orders.each do |order| %>
     <tr>
       <td>
-        <% order.order_items.each do |item| %>
-          <%= item.item.name %><br>
+        <% order.order_details.each do |detail| %>
+        <%= detail.item.name %><br>
         <% end %>
       </td>
       <td><%= number_to_currency(order.total_payment) %></td>


### PR DESCRIPTION
マイページ→注文履歴の際のエラーを解消。
アカウントに複数配送先が登録されているときに注文に進む際にエラーが発生するのを解消。
（配送先が１つしか登録されていなければエラーはない状態でした。）